### PR TITLE
Add Go tests for runtime (de-)serialise pairs.

### DIFF
--- a/runtime/session2/message_test.go
+++ b/runtime/session2/message_test.go
@@ -1,0 +1,296 @@
+package session2
+
+import (
+	"bytes"
+	"encoding/gob"
+	"io"
+	"testing"
+)
+
+type fakeChan struct {
+	buf *bytes.Buffer
+	ptr chan interface{}
+}
+
+func newFakeChan(N int) *fakeChan {
+	return &fakeChan{new(bytes.Buffer), make(chan interface{}, N)}
+}
+func (c *fakeChan) GetReader() io.Reader       { return c.buf }
+func (c *fakeChan) GetWriter() io.Writer       { return c.buf }
+func (c *fakeChan) Close() error               { return nil }
+func (c *fakeChan) ReadPointer(m *interface{}) { *m = <-c.ptr }
+func (c *fakeChan) WritePointer(m interface{}) { c.ptr <- m }
+
+// mockISend is a mocked MPChan.ISend function.
+func mockISend(fmt ScribMessageFormatter, val interface{}) error {
+	return fmt.Serialize(wrapper{val})
+}
+
+// mockIRecv is a mocked Fake MPChan.IRecv function.
+func mockIRecv(fmtr ScribMessageFormatter, ptr *interface{}) error {
+	var msg ScribMessage
+	if err := fmtr.Deserialize(&msg); err != nil {
+		return err
+	}
+	*ptr = msg.(wrapper).Msg
+	return nil
+}
+
+type transport struct {
+	name       string
+	sFmt, rFmt ScribMessageFormatter
+}
+
+func newFakeTransports(N int) []transport {
+	transports := []transport{
+		transport{"shm", new(PassByPointer), new(PassByPointer)},
+		transport{"tcp", new(GobFormatter), new(GobFormatter)},
+	}
+	for _, transport := range transports {
+		ch := newFakeChan(N)
+		transport.sFmt.Wrap(ch)
+		transport.rFmt.Wrap(ch)
+	}
+	return transports
+}
+
+// This covers the cases when the message is of format: Label(int)
+func TestSerialisePrimitiveType(t *testing.T) {
+	transports := newFakeTransports(3)
+
+	toSend := []int{1, 2, 3}
+	toRecv := make([]int, 3)
+
+	for _, transport := range transports {
+		t.Run(transport.name, func(t *testing.T) {
+			// Send
+			for i := range toSend {
+				if err := mockISend(transport.sFmt, &toSend[i]); err != nil {
+					t.Errorf("serialise failed: %v", err)
+				}
+			}
+			// Receive
+			for i := range toRecv {
+				var tmp interface{}
+				if err := mockIRecv(transport.rFmt, &tmp); err != nil {
+					t.Errorf("deserialise failed: %v", err)
+				}
+				toRecv[i] = *(tmp.(*int))
+			}
+			if want, got := len(toSend), len(toRecv); want != got {
+				t.Errorf("mismatch: sent %d items but received %d", want, got)
+			}
+			for i := range toSend {
+				if want, got := toSend[i], toRecv[i]; want != got {
+					t.Errorf("mismatch at %d: sent %#v but got %#v", i, want, got)
+				}
+			}
+		})
+	}
+}
+
+// This covers the cases when the message is of format: Label(StructType)
+// where type StructType struct { Field int }
+func TestSerialiseStructType(t *testing.T) {
+	transports := newFakeTransports(3)
+
+	type StructType struct {
+		Field int
+	}
+
+	toSend := []StructType{StructType{1}, StructType{2}, StructType{3}}
+	toRecv := make([]StructType, 3)
+
+	for _, transport := range transports {
+		t.Run(transport.name, func(t *testing.T) {
+			gob.Register(new(StructType)) // Register type
+			// Send
+			for i := range toSend {
+				if err := mockISend(transport.sFmt, &toSend[i]); err != nil {
+					t.Errorf("serialise failed: %v", err)
+				}
+			}
+			// Receive
+			for i := range toRecv {
+				var tmp interface{}
+				if err := mockIRecv(transport.rFmt, &tmp); err != nil {
+					t.Errorf("deserialise failed: %v", err)
+				}
+				toRecv[i] = *(tmp.(*StructType))
+			}
+			if want, got := len(toSend), len(toRecv); want != got {
+				t.Errorf("mismatch: sent %d items but received %d", want, got)
+			}
+			for i := range toSend {
+				if want, got := toSend[i], toRecv[i]; want != got {
+					t.Errorf("mismatch at %d: sent %#v but got %#v", i, want, got)
+				}
+			}
+		})
+	}
+}
+
+// This covers the cases when the message is of format: Sig declared as sig
+// where type Sig int
+func TestSerialiseNamedSig(t *testing.T) {
+	transports := newFakeTransports(3)
+
+	type NamedSig int
+
+	toSend := []NamedSig{NamedSig(1), NamedSig(2), NamedSig(3)}
+	toRecv := make([]NamedSig, 3)
+
+	for _, transport := range transports {
+		t.Run(transport.name, func(t *testing.T) {
+			gob.Register(new(NamedSig)) // Register type
+			// Send
+			for i := range toSend {
+				if err := mockISend(transport.sFmt, &toSend[i]); err != nil {
+					t.Errorf("serialise failed: %v", err)
+				}
+			}
+			// Receive
+			for i := range toRecv {
+				var tmp interface{}
+				if err := mockIRecv(transport.rFmt, &tmp); err != nil {
+					t.Errorf("deserialise failed: %v", err)
+				}
+				toRecv[i] = *tmp.(*NamedSig)
+			}
+			if want, got := len(toSend), len(toRecv); want != got {
+				t.Errorf("mismatch: sent %d items but received %d", want, got)
+			}
+			for i := range toSend {
+				if want, got := toSend[i], toRecv[i]; want != got {
+					t.Errorf("mismatch at %d: sent %#v but got %#v", i, want, got)
+				}
+			}
+		})
+	}
+}
+
+// This covers the cases when the message is of format: StructSig declared as sig
+// where type StructSig struct { Field int }
+func TestSerialiseStructSig(t *testing.T) {
+	transports := newFakeTransports(3)
+
+	type StructSig struct {
+		Field int
+	}
+
+	toSend := []StructSig{StructSig{1}, StructSig{2}, StructSig{3}}
+	toRecv := make([]StructSig, 3)
+
+	for _, transport := range transports {
+		t.Run(transport.name, func(t *testing.T) {
+			gob.Register(new(StructSig)) // Register type
+			// Send
+			for i := range toSend {
+				if err := mockISend(transport.sFmt, &toSend[i]); err != nil {
+					t.Errorf("serialise failed: %v", err)
+				}
+			}
+			// Receive
+			for i := range toRecv {
+				var tmp interface{}
+				if err := mockIRecv(transport.rFmt, &tmp); err != nil {
+					t.Errorf("deserialise failed: %v", err)
+				}
+				toRecv[i] = *tmp.(*StructSig)
+			}
+			if want, got := len(toSend), len(toRecv); want != got {
+				t.Errorf("mismatch: sent %d items but received %d", want, got)
+			}
+			for i := range toSend {
+				if want, got := toSend[i].Field, toRecv[i].Field; want != got {
+					t.Errorf("mismatch at %d: sent %#v but got %#v", i, want, got)
+				}
+			}
+		})
+	}
+}
+
+// This covers the cases when the message is of format: StructPtrFieldSig declared as sig
+// where type StructPtrFieldSig struct { Field *int }
+func TestSerialiseStructPtrFieldSig(t *testing.T) {
+	transports := newFakeTransports(3)
+
+	type StructPtrFieldSig struct {
+		Field *int
+	}
+
+	i0, i1, i2 := 1, 2, 3
+	toSend := []StructPtrFieldSig{
+		StructPtrFieldSig{&i0},
+		StructPtrFieldSig{&i1},
+		StructPtrFieldSig{&i2},
+	}
+	toRecv := make([]StructPtrFieldSig, 3)
+
+	for _, transport := range transports {
+		t.Run(transport.name, func(t *testing.T) {
+			gob.Register(new(StructPtrFieldSig)) // Register type
+			// Send
+			for i := range toSend {
+				if err := mockISend(transport.sFmt, &toSend[i]); err != nil {
+					t.Errorf("serialise failed: %v", err)
+				}
+			}
+			// Receive
+			for i := range toRecv {
+				var tmp interface{}
+
+				if err := mockIRecv(transport.rFmt, &tmp); err != nil {
+					t.Errorf("deserialise failed: %v", err)
+				}
+				toRecv[i] = *tmp.(*StructPtrFieldSig)
+			}
+			if want, got := len(toSend), len(toRecv); want != got {
+				t.Errorf("mismatch: sent %d items but received %d", want, got)
+			}
+			for i := range toSend {
+				if want, got := *toSend[i].Field, *toRecv[i].Field; want != got {
+					t.Errorf("mismatch at %d: sent %#v but got %#v", i, want, got)
+				}
+			}
+		})
+	}
+}
+
+// This covers the cases when the message is of format: PtrPrimitiveSig declared as sig
+// where type PtrPrimitiveSig *int
+func TestSerialisePtrPrimitiveSig(t *testing.T) {
+	transports := newFakeTransports(3)[0:0] // Note: only test shm version.
+
+	i0, i1, i2 := 1, 2, 3
+	toSend := []*int{&i0, &i1, &i2}
+	toRecv := make([]*int, 3)
+
+	for _, transport := range transports {
+		t.Run(transport.name, func(t *testing.T) {
+			// Send
+			for i := range toSend {
+				if err := mockISend(transport.sFmt, &toSend[i]); err != nil {
+					t.Errorf("serialise failed: %v", err)
+				}
+			}
+			// Receive
+			for i := range toRecv {
+				var tmp interface{}
+
+				if err := mockIRecv(transport.rFmt, &tmp); err != nil {
+					t.Errorf("deserialise failed: %v", err)
+				}
+				toRecv[i] = *tmp.(**int)
+			}
+			if want, got := len(toSend), len(toRecv); want != got {
+				t.Errorf("mismatch: sent %d items but received %d", want, got)
+			}
+			for i := range toSend {
+				if want, got := *toSend[i], *toRecv[i]; want != got {
+					t.Errorf("mismatch at %d: sent %#v but got %#v", i, want, got)
+				}
+			}
+		})
+	}
+}

--- a/test/shm/shm01/main.go
+++ b/test/shm/shm01/main.go
@@ -2,6 +2,8 @@
 //$ go install github.com/rhu1/scribble-go-runtime/test/shm/shm01
 //$ bin/shm01.exe
 
+//go:generate scribblec-param.sh Shm1.scr -d . -param Proto1 github.com/rhu1/scribble-go-runtime/test/shm/shm01/Shm1 -param-api S -param-api W
+
 package main
 
 import (

--- a/test/shm/shm02/main.go
+++ b/test/shm/shm02/main.go
@@ -2,6 +2,8 @@
 //$ go install github.com/rhu1/scribble-go-runtime/test/shm/shm02
 //$ bin/shm02.exe
 
+//go:generate scribblec-param.sh Shm2.scr -d . -param Proto1 github.com/rhu1/scribble-go-runtime/test/shm/shm02/Shm2 -param-api S -param-api W
+
 package main
 
 import (

--- a/test/shm/shm03/main.go
+++ b/test/shm/shm03/main.go
@@ -2,6 +2,8 @@
 //$ go install github.com/rhu1/scribble-go-runtime/test/shm/shm03
 //$ bin/shm03.exe
 
+//go:generate scribblec-param.sh Shm3.scr -d . -param Proto1 github.com/rhu1/scribble-go-runtime/test/shm/shm03/Shm3 -param-api S -param-api W
+
 package main
 
 import (

--- a/test/shm/shm04/main.go
+++ b/test/shm/shm04/main.go
@@ -2,6 +2,8 @@
 //$ go install github.com/rhu1/scribble-go-runtime/test/shm/shm04
 //$ bin/shm04.exe
 
+//go:generate scribblec-param.sh Shm4.scr -d . -param Proto1 github.com/rhu1/scribble-go-runtime/test/shm/shm04/Shm4 -param-api S -param-api W
+
 package main
 
 import (

--- a/test/shm/shm05/main.go
+++ b/test/shm/shm05/main.go
@@ -2,6 +2,8 @@
 //$ go install github.com/rhu1/scribble-go-runtime/test/shm/shm05
 //$ bin/shm05.exe
 
+//go:generate scribblec-param.sh Shm5.scr -d . -param Proto1 github.com/rhu1/scribble-go-runtime/test/shm/shm05/Shm5 -param-api S -param-api W
+
 package main
 
 import (

--- a/test/shm/shm06/main.go
+++ b/test/shm/shm06/main.go
@@ -2,6 +2,8 @@
 //$ go install github.com/rhu1/scribble-go-runtime/test/shm/shm06
 //$ bin/shm06.exe
 
+//go:generate scribblec-param.sh Shm6.scr -d . -param Proto1 github.com/rhu1/scribble-go-runtime/test/shm/shm06/Shm6 -param-api S -param-api W
+
 package main
 
 import (


### PR DESCRIPTION
shm01 → Primitive types - TestSerialisePrimitive Type
shm02 → Struct types - TestSerialiseStructType
shm03 → Named type (typedef) - TestSerialiseNamedSig
shm04 → Struct sig (value field) - TestSerialiseStructSig
shm05 → Struct sig (pointer field) - TestSerialiseStructPtrFieldSig
shm05 → Pointer-to-primitive types - TestSerialisePtrPrimitiveSig

The commit also adds `go:generate` compiler directive for the corresponding tests.