### PR TITLE
Change message passing runtime API to be symmetric.

### DIFF
--- a/runtime/session2/message.go
+++ b/runtime/session2/message.go
@@ -55,8 +55,8 @@ func (f *GobFormatter) Wrap(c transport2.BinChannel) {
 
 func (f *GobFormatter) Serialize(m ScribMessage) error {
 	//fmt.Printf("Serialize: %v %T\n", m, m)
-	return f.enc.Encode(&m)  // Encode *ScribMessage  // CHECKME just m? not &m
-		// "val" should be m
+	return f.enc.Encode(m.(wrapper).Msg) // Encode *ScribMessage  // CHECKME just m? not &m
+	// "val" should be m
 }
 
 func (f *GobFormatter) Deserialize(m *ScribMessage) (error) {
@@ -65,8 +65,9 @@ func (f *GobFormatter) Deserialize(m *ScribMessage) (error) {
 	//f.rdr.Read(b)
 	//fmt.Printf("To deserialise\n", b)
 
-  err := f.dec.Decode(m)  // Decode *ScribMessage
-	  // pointer, "m" is *
+	msg := (*m).(wrapper).Msg
+	err := f.dec.Decode(msg) // Decode *ScribMessage
+	// pointer, "m" is *
 
 	//fmt.Printf("Deserialize2: %v %T\n", *m, *m)
 

--- a/runtime/session2/message_test.go
+++ b/runtime/session2/message_test.go
@@ -71,11 +71,9 @@ func TestSerialisePrimitiveType(t *testing.T) {
 			}
 			// Receive
 			for i := range toRecv {
-				var tmp interface{}
-				if err := mockIRecv(transport.rFmt, &tmp); err != nil {
+				if err := mockIRecv(transport.rFmt, &toRecv[i]); err != nil {
 					t.Errorf("deserialise failed: %v", err)
 				}
-				toRecv[i] = *(tmp.(*int))
 			}
 			if want, got := len(toSend), len(toRecv); want != got {
 				t.Errorf("mismatch: sent %d items but received %d", want, got)
@@ -112,11 +110,9 @@ func TestSerialiseStructType(t *testing.T) {
 			}
 			// Receive
 			for i := range toRecv {
-				var tmp interface{}
-				if err := mockIRecv(transport.rFmt, &tmp); err != nil {
+				if err := mockIRecv(transport.rFmt, &toRecv[i]); err != nil {
 					t.Errorf("deserialise failed: %v", err)
 				}
-				toRecv[i] = *(tmp.(*StructType))
 			}
 			if want, got := len(toSend), len(toRecv); want != got {
 				t.Errorf("mismatch: sent %d items but received %d", want, got)
@@ -151,11 +147,9 @@ func TestSerialiseNamedSig(t *testing.T) {
 			}
 			// Receive
 			for i := range toRecv {
-				var tmp interface{}
-				if err := mockIRecv(transport.rFmt, &tmp); err != nil {
+				if err := mockIRecv(transport.rFmt, &toRecv[i]); err != nil {
 					t.Errorf("deserialise failed: %v", err)
 				}
-				toRecv[i] = *tmp.(*NamedSig)
 			}
 			if want, got := len(toSend), len(toRecv); want != got {
 				t.Errorf("mismatch: sent %d items but received %d", want, got)
@@ -192,11 +186,9 @@ func TestSerialiseStructSig(t *testing.T) {
 			}
 			// Receive
 			for i := range toRecv {
-				var tmp interface{}
-				if err := mockIRecv(transport.rFmt, &tmp); err != nil {
+				if err := mockIRecv(transport.rFmt, &toRecv[i]); err != nil {
 					t.Errorf("deserialise failed: %v", err)
 				}
-				toRecv[i] = *tmp.(*StructSig)
 			}
 			if want, got := len(toSend), len(toRecv); want != got {
 				t.Errorf("mismatch: sent %d items but received %d", want, got)
@@ -225,7 +217,11 @@ func TestSerialiseStructPtrFieldSig(t *testing.T) {
 		StructPtrFieldSig{&i1},
 		StructPtrFieldSig{&i2},
 	}
-	toRecv := make([]StructPtrFieldSig, 3)
+	toRecv := []StructPtrFieldSig{
+		StructPtrFieldSig{},
+		StructPtrFieldSig{},
+		StructPtrFieldSig{},
+	}
 
 	for _, transport := range transports {
 		t.Run(transport.name, func(t *testing.T) {
@@ -238,12 +234,9 @@ func TestSerialiseStructPtrFieldSig(t *testing.T) {
 			}
 			// Receive
 			for i := range toRecv {
-				var tmp interface{}
-
-				if err := mockIRecv(transport.rFmt, &tmp); err != nil {
+				if err := mockIRecv(transport.rFmt, &toRecv[i]); err != nil {
 					t.Errorf("deserialise failed: %v", err)
 				}
-				toRecv[i] = *tmp.(*StructPtrFieldSig)
 			}
 			if want, got := len(toSend), len(toRecv); want != got {
 				t.Errorf("mismatch: sent %d items but received %d", want, got)
@@ -276,12 +269,9 @@ func TestSerialisePtrPrimitiveSig(t *testing.T) {
 			}
 			// Receive
 			for i := range toRecv {
-				var tmp interface{}
-
-				if err := mockIRecv(transport.rFmt, &tmp); err != nil {
+				if err := mockIRecv(transport.rFmt, &toRecv[i]); err != nil {
 					t.Errorf("deserialise failed: %v", err)
 				}
-				toRecv[i] = *tmp.(**int)
 			}
 			if want, got := len(toSend), len(toRecv); want != got {
 				t.Errorf("mismatch: sent %d items but received %d", want, got)

--- a/runtime/session2/mpchan.go
+++ b/runtime/session2/mpchan.go
@@ -57,7 +57,7 @@ func NewMPChan(self int, rolenames []string) *MPChan {
 // Pre: msg is a pointer value
 func (ep *MPChan) ISend(rolename string, i int, msg interface{}) error {
 	//fmt.Printf("ISend %v %T\n", msg, msg)
-	return ep.MSend(rolename, i, wrapper{Msg:msg})  // CHECKME: &wrapper?
+	return ep.MSend(rolename, i, wrapper{Msg: msg}) // CHECKME: &wrapper?
 }
 
 // Could just use interface{}?  but specify *interface{} as typing info?

--- a/runtime/session2/mpchan.go
+++ b/runtime/session2/mpchan.go
@@ -62,13 +62,10 @@ func (ep *MPChan) ISend(rolename string, i int, msg interface{}) error {
 
 // Could just use interface{}?  but specify *interface{} as typing info?
 // N.B. the "interface{}" part is itself a pointer, cf. ISend
-func (ep *MPChan) IRecv(rolename string, i int, msg *interface{}) error {
-	var w ScribMessage
+func (ep *MPChan) IRecv(rolename string, i int, msg interface{}) error {
+	var w ScribMessage = wrapper{msg}
 	err := ep.MRecv(rolename, i, &w)
 	//fmt.Printf("IRecv %v %T \n", w.(wrapper).Msg, w.(wrapper).Msg)
-	if err == nil {
-		*msg = w.(wrapper).Msg
-	}
 	return err
 }
 

--- a/runtime/transport2/shm/shm.go
+++ b/runtime/transport2/shm/shm.go
@@ -140,7 +140,7 @@ func Dial(_ string, port int) (transport2.BinChannel, error) {
 	defer ports.mu.Unlock()
 	ch, exists := ports.chans[port]
 	if !exists {
-		return nil, io.ErrClosedPipe
+		return nil, fmt.Errorf("shm: dial failed: port %d does not exist", port)
 	}
 	c := Channel{
 		rdRx: ch.cb2, rdTx: ch.cn2, rdPtr: ch.cp2,

--- a/runtime/transport2/shm/shm.go
+++ b/runtime/transport2/shm/shm.go
@@ -17,6 +17,7 @@ type sharedChan struct {
 	cn2 chan int
 	cp1 chan interface{}
 	cp2 chan interface{}
+	blk chan struct{} // block until connected
 }
 
 func newSharedChan() *sharedChan {
@@ -27,6 +28,7 @@ func newSharedChan() *sharedChan {
 		cn2: make(chan int),
 		cp1: make(chan interface{}),
 		cp2: make(chan interface{}),
+		blk: make(chan struct{}),
 	}
 }
 
@@ -92,6 +94,7 @@ func (ln *Listener) Accept() (transport2.BinChannel, error) {
 		rdRx: ln.ch.cb1, rdTx: ln.ch.cn1, rdPtr: ln.ch.cp1,
 		wrTx: ln.ch.cb2, wrRx: ln.ch.cn2, wrPtr: ln.ch.cp2,
 	}
+	<-ln.ch.blk
 	return &c, nil
 }
 
@@ -148,5 +151,6 @@ func Dial(_ string, port int) (transport2.BinChannel, error) {
 		rdRx: ch.cb2, rdTx: ch.cn2, rdPtr: ch.cp2,
 		wrTx: ch.cb1, wrRx: ch.cn1, wrPtr: ch.cp1,
 	}
+	close(ch.blk)
 	return &c, nil
 }

--- a/runtime/transport2/shm/shm.go
+++ b/runtime/transport2/shm/shm.go
@@ -96,6 +96,8 @@ func (ln *Listener) Accept() (transport2.BinChannel, error) {
 }
 
 func (ln *Listener) Close() error {
+	ports.mu.Lock()
+	defer ports.mu.Unlock()
 	delete(ports.chans, ln.port)
 	return nil
 }

--- a/runtime/transport2/shm/shm_test.go
+++ b/runtime/transport2/shm/shm_test.go
@@ -3,6 +3,7 @@ package shm_test
 import (
 	"bytes"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/rhu1/scribble-go-runtime/runtime/session2"
@@ -14,16 +15,12 @@ func TestRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	server, err := ln.Accept()
-	if err != nil {
-		t.Error(err)
-	}
-	client, err := shm.Dial("", 1)
-	if err != nil {
-		t.Error(err)
-	}
 	input := []byte("This is the round trip message.")
 	go func() {
+		server, err := ln.Accept()
+		if err != nil {
+			t.Error(err)
+		}
 		r := bytes.NewReader(input)
 		inputLen := int64(len(input))
 		n, err := io.CopyN(server.GetWriter(), r, inputLen) // message to server
@@ -37,6 +34,10 @@ func TestRoundTrip(t *testing.T) {
 		}
 		t.Logf("Server forwarded %d bytes", n)
 	}()
+	client, err := shm.Dial("", 1)
+	if err != nil {
+		t.Error(err)
+	}
 
 	inputLen := int64(len(input))
 	n, err := io.CopyN(client.GetWriter(), client.GetReader(), inputLen)
@@ -70,21 +71,21 @@ func TestRoundTripPointer(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	server, err := ln.Accept()
-	if err != nil {
-		t.Error(err)
-	}
-	client, err := shm.Dial("", 1)
-	if err != nil {
-		t.Error(err)
-	}
 	go func() {
+		client, err := shm.Dial("", 1)
+		if err != nil {
+			t.Error(err)
+		}
 		var clientMsg interface{} = &msg{}
 		client.(session2.PointerReader).ReadPointer(&clientMsg)
 		clientMsg.(*msg).V++
 		client.(session2.PointerWriter).WritePointer(clientMsg)
 	}()
 
+	server, err := ln.Accept()
+	if err != nil {
+		t.Error(err)
+	}
 	var serverMsg interface{} = &msg{V: 41}
 	server.(session2.PointerWriter).WritePointer(serverMsg)
 	server.(session2.PointerReader).ReadPointer(&serverMsg)
@@ -95,4 +96,44 @@ func TestRoundTripPointer(t *testing.T) {
 	if err := ln.Close(); err != nil {
 		t.Error(err)
 	}
+}
+
+func TestSynchronousConnection(t *testing.T) {
+	port := 10
+	wg := new(sync.WaitGroup)
+	wg.Add(2)
+	go func(port int, wg *sync.WaitGroup) {
+		ch, err := shm.Dial("", port)
+		if err != nil {
+			t.Fatalf("shm: dial to :%d failed: %v", port, err)
+		}
+		defer func() {
+			if err := ch.Close(); err != nil {
+				t.Errorf("shm: close failed: %v", err)
+			}
+		}()
+		wg.Done()
+	}(port, wg)
+	go func(port int, wg *sync.WaitGroup) {
+		ln, err := shm.Listen(port)
+		if err != nil {
+			t.Fatalf("cannot create listener: %v", err)
+		}
+		ch, err := ln.Accept()
+		if err != nil {
+			t.Fatalf("shm: cannot accept: %v", err)
+		}
+		defer func() {
+			if err := ln.Close(); err != nil {
+				t.Errorf("shm: listener close failed: %v", err)
+			}
+		}()
+		defer func() {
+			if err := ch.Close(); err != nil {
+				t.Errorf("shm: close failed: %v", err)
+			}
+		}()
+		wg.Done()
+	}(port, wg)
+	wg.Wait()
 }

--- a/test/deleg/deleg01/main.go
+++ b/test/deleg/deleg01/main.go
@@ -2,6 +2,9 @@
 //$ go install github.com/rhu1/scribble-go-runtime/test/deleg/deleg01
 //$ bin/deleg01.exe
 
+//go:generate scribblec-param.sh Deleg1.scr -d . -param Proto2 github.com/rhu1/scribble-go-runtime/test/deleg/deleg01/Deleg1 -param-api A -param-api B
+//go:generate scribblec-param.sh Deleg1.scr -d . -param Proto1 github.com/rhu1/scribble-go-runtime/test/deleg/deleg01/Deleg1 -param-api S -param-api W
+
 package main
 
 import (

--- a/test/deleg/deleg02/main.go
+++ b/test/deleg/deleg02/main.go
@@ -2,6 +2,9 @@
 //$ go install github.com/rhu1/scribble-go-runtime/test/deleg/deleg02
 //$ bin/deleg02.exe
 
+//go:generate scribblec-param.sh Deleg2.scr -d . -param Proto2 github.com/rhu1/scribble-go-runtime/test/deleg/deleg02/Deleg2 -param-api A -param-api B
+//go:generate scribblec-param.sh Deleg2.scr -d . -param Proto1 github.com/rhu1/scribble-go-runtime/test/deleg/deleg02/Deleg2 -param-api S -param-api W
+
 package main
 
 import (

--- a/test/deleg/deleg03/main.go
+++ b/test/deleg/deleg03/main.go
@@ -2,6 +2,9 @@
 //$ go install github.com/rhu1/scribble-go-runtime/test/deleg/deleg03
 //$ bin/deleg03.exe
 
+//go:generate scribblec-param.sh Deleg3.scr -d . -param Proto2 github.com/rhu1/scribble-go-runtime/test/deleg/deleg03/Deleg3 -param-api A -param-api B
+//go:generate scribblec-param.sh Deleg3.scr -d . -param Proto1 github.com/rhu1/scribble-go-runtime/test/deleg/deleg03/Deleg3 -param-api S -param-api W
+
 package main
 
 import (


### PR DESCRIPTION
This PR changes the runtime as per discussed (option 2) in nickng/scribble-go#1, allowing different `ScribFormatter` implementations to work using the same API.

This requires rhu1/scribble-java changes.