### PR TITLE
Documentation

### DIFF
--- a/runtime/session2/message.go
+++ b/runtime/session2/message.go
@@ -1,52 +1,58 @@
 package session2
 
 import (
-	//"bytes"
-	//"encoding/base64"
 	"encoding/gob"
-	"fmt"
-	"io"
 	"unsafe"
 
 	"github.com/rhu1/scribble-go-runtime/runtime/transport2"
 )
 
-var _ = fmt.Print
-
-
-// cf. org.scribble.runtime.net.ScribMessage
+// ScribMessage represents a basic message.
+//
+// Corresponds to Scribble Java runtime's
+// org.scribble.runtime.net.ScribMessage class
 type ScribMessage interface {
 	GetOp() string
 }
 
-// cf. org.scribble.runtime.net.ScribMessageFormatter
+// ScribMessageFormatter represents a message formatter (or serialiser).
+//
+// Corresponds to Scribble Java runtime's
+// org.scribble.runtime.net.ScribMessageFormatter class
 type ScribMessageFormatter interface {
-	Wrap(transport2.BinChannel) 	
-	Serialize(ScribMessage) error
-	Deserialize(*ScribMessage) error
+	// Wrap wraps a given binary channel with the formatter.
+	// The channel is the target input and output stream for
+	// serialisation and deserialisation using the formatter.
+	Wrap(c transport2.BinChannel)
 
-	/*EncodeInt(int) error
-	DecodeInt() (int, error)
-	EncodeString(string) error
-	DecodeString() (string, error)
-	EncodeBytes([]byte) error
-	DecodeBytes() ([]byte, error)*/
-	
-	/*GetEnc() *gob.Encoder
-	GetDec() *gob.Decoder*/
+	// Serialize serialises the given message m the writes to
+	// the underlying output stream.
+	Serialize(m ScribMessage) error
+
+	// Deserialize read from the underlying input stream and
+	// deserialises the message into the message container m.
+	Deserialize(m *ScribMessage) error
 }
 
-
-/**
- * N.B. must do gob.Register on _pointer_ to message types (cf. sigs02, shm03) -- because MPChan MSend/Receive communicate by pointer (for efficient transparency with shm)
- */
+// GobFormatter is an implementation of a ScribMessageFormatter using
+// Go's "encoding/gob" package.
+//
+// User must manually run gob.Register on the message type pointer
+// to register the message type for encoding.
+//
+//     // T is type being sent/received
+//     gob.Register(new(T))
+//
+// The snippet above registers type T for sending and receiving.
+//
 type GobFormatter struct {
-	c transport2.BinChannel
+	c   transport2.BinChannel
 	enc *gob.Encoder
 	dec *gob.Decoder
 	rdr io.Reader
 }
 
+// Wrap wraps a binary channel for gob encoding.
 func (f *GobFormatter) Wrap(c transport2.BinChannel) {
 	f.c = c
 	f.enc = gob.NewEncoder(c.GetWriter())
@@ -54,62 +60,79 @@ func (f *GobFormatter) Wrap(c transport2.BinChannel) {
 	f.dec = gob.NewDecoder(f.rdr)
 }
 
+// Serialize encodes a ScribMessage m using gob.
+//
+// The message type implementing ScribMessage should be
+// registered before calling this method.
 func (f *GobFormatter) Serialize(m ScribMessage) error {
-	//fmt.Printf("Serialize: %v %T\n", m, m)
+	// If the message is recognised as a special message type,
+	// use special encoding strategy.
 	switch smsg := m.(type) {
 	case wrapper:
 		return f.enc.Encode(smsg.Msg)
-	default:
-		return f.enc.Encode(&m) // Encode *ScribMessage  // CHECKME just m? not &m
 	}
-	// "val" should be m
+	// Encode ScribMessage as-is.
+	return f.enc.Encode(&m)
 }
 
+// Deserialize decode a ScribMessage m using gob.
+//
+// The message type implementing ScribMessage should be
+// registered before calling this method.
 func (f *GobFormatter) Deserialize(m *ScribMessage) error {
-	//fmt.Printf("Deserialize1: %v %T\n", *m, *m)
-	//b := make([]byte, 100)
-	//f.rdr.Read(b)
-	//fmt.Printf("To deserialise\n", b)
-
+	// If the message container is recognised as a special message type,
+	// use special decoding strategy.
 	switch smeg := (*m).(type) {
 	case wrapper:
 		msg := smeg.Msg
 		return f.dec.Decode(msg)
-	default:
-		return f.dec.Decode(m) // Decode *ScribMessage
 	}
-	// pointer, "m" is *
-
-	//fmt.Printf("Deserialize2: %v %T\n", *m, *m)
+	// Decode ScribMessage as-is.
+	return f.dec.Decode(m)
 }
 
 // PointerWriter is an interface for writing a pointer ptr to a channel.
+//
+// Transports supporting transparent movement
+// of memory should implement this interface.
 type PointerWriter interface {
 	WritePointer(ptr interface{})
 }
 
 // PointerReader is an interface for reading a pointer from a channel
 // and write the received content to ptr.
+//
+// Transports supporting transparent movement
+// of memory should implement this interface.
 type PointerReader interface {
 	ReadPointer(ptr *interface{})
 }
 
 // PointerReadWriter is an interface for reading and writing
 // a pointer over a channel.
+//
+// Transports supporting transparent movement
+// of memory should implement this interface.
 type PointerReadWriter interface {
 	PointerWriter
 	PointerReader
 }
 
-// FIXME: (rename?) and move to shm package
+// PassByPointer is an implementation of ScribMessageFormatter
+// using pointer passing.
+//
+// This is formatter is only available for transports
+// implementing PointerReadWriter.
 type PassByPointer struct {
 	c PointerReadWriter
 }
 
+// Wrap wraps a binary channel for pointer encoding.
 func (f *PassByPointer) Wrap(c transport2.BinChannel) {
 	f.c = c.(PointerReadWriter)
 }
 
+// Serialize encodes a ScribMessage m as pointer.
 func (f *PassByPointer) Serialize(m ScribMessage) error {
 	switch m := m.(type) {
 	case wrapper:
@@ -121,6 +144,7 @@ func (f *PassByPointer) Serialize(m ScribMessage) error {
 	return nil
 }
 
+// Deserialize decodes a ScribMessage m as pointer.
 func (f *PassByPointer) Deserialize(m *ScribMessage) error {
 	switch smsg := (*m).(type) {
 	case wrapper:
@@ -158,41 +182,3 @@ func derefIface(iface interface{}) unsafe.Pointer {
 	// contains pointer to the underlying value in the interface{} variable
 	return *(*unsafe.Pointer)(unsafe.Pointer(uintptr(unsafe.Pointer(&iface)) + unsafe.Sizeof(word)))
 }
-
-/*func (f *GobFormatter) EncodeInt(m int) error {
-	return f.enc.Encode(&m)
-}
-
-func (f *GobFormatter) DecodeInt() (int, error) {
-	var m int
-	err := f.dec.Decode(&m)
-	return m, err
-}
-
-func (f *GobFormatter) EncodeString(m string) error {
-	return f.enc.Encode(&m)
-}
-
-func (f *GobFormatter) DecodeString() (string, error) {
-	var m string
-	err := f.dec.Decode(&m)
-	return m, err
-}
-
-func (f *GobFormatter) EncodeBytes(m []byte) error {
-	return f.enc.Encode(&m)
-}
-
-func (f *GobFormatter) DecodeBytes() ([]byte, error) {
-	var m []byte
-	err := f.dec.Decode(&m)
-	return m, err
-}*/
-
-/*func (f *GobFormatter) GetEnc() *gob.Encoder {
-	return f.enc
-}
-
-func (f *GobFormatter) GetDec() *gob.Decoder {
-	return f.dec
-}*/

--- a/runtime/session2/message.go
+++ b/runtime/session2/message.go
@@ -49,15 +49,13 @@ type GobFormatter struct {
 	c   transport2.BinChannel
 	enc *gob.Encoder
 	dec *gob.Decoder
-	rdr io.Reader
 }
 
 // Wrap wraps a binary channel for gob encoding.
 func (f *GobFormatter) Wrap(c transport2.BinChannel) {
 	f.c = c
-	f.enc = gob.NewEncoder(c.GetWriter())
-	f.rdr = c.GetReader()
-	f.dec = gob.NewDecoder(f.rdr)
+	f.enc = gob.NewEncoder(c)
+	f.dec = gob.NewDecoder(c)
 }
 
 // Serialize encodes a ScribMessage m using gob.

--- a/runtime/session2/message_test.go
+++ b/runtime/session2/message_test.go
@@ -48,34 +48,129 @@ func newFakeTransports(N int) []transport {
 func TestSerialisePrimitiveType(t *testing.T) {
 	transports := newFakeTransports(3)
 
-	toSend := []int{1, 2, 3}
-	toRecv := make([]int, 3)
+	t.Run("int", func(t *testing.T) {
+		toSend := []int{1, 2, 3}
+		toRecv := make([]int, 3)
 
-	for _, transport := range transports {
-		t.Run(transport.name, func(t *testing.T) {
-			mpc := mockMPChan(transport.sFmt)
-			// Send
-			for i := range toSend {
-				if err := mpc.ISend("", 0, &toSend[i]); err != nil {
-					t.Errorf("serialise failed: %v", err)
+		for _, transport := range transports {
+			t.Run(transport.name, func(t *testing.T) {
+				mpc := mockMPChan(transport.sFmt)
+				// Send
+				for i := range toSend {
+					if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+						t.Errorf("serialise failed: %v", err)
+					}
 				}
-			}
-			// Receive
-			for i := range toRecv {
-				if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
-					t.Errorf("deserialise failed: %v", err)
+				// Receive
+				for i := range toRecv {
+					if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+						t.Errorf("deserialise failed: %v", err)
+					}
 				}
-			}
-			if want, got := len(toSend), len(toRecv); want != got {
-				t.Errorf("mismatch: sent %d items but received %d", want, got)
-			}
-			for i := range toSend {
-				if want, got := toSend[i], toRecv[i]; want != got {
-					t.Errorf("mismatch at %d: sent %#v but got %#v", i, want, got)
+				if want, got := len(toSend), len(toRecv); want != got {
+					t.Errorf("mismatch: sent %d items but received %d", want, got)
 				}
-			}
-		})
-	}
+				for i := range toSend {
+					if want, got := toSend[i], toRecv[i]; want != got {
+						t.Errorf("mismatch at %d: sent %#v but got %#v", i, want, got)
+					}
+				}
+			})
+		}
+	})
+	t.Run("float32", func(t *testing.T) {
+		toSend := []float32{0.01, 0.02, 0.03}
+		toRecv := make([]float32, 3)
+
+		for _, transport := range transports {
+			t.Run(transport.name, func(t *testing.T) {
+				mpc := mockMPChan(transport.sFmt)
+				// Send
+				for i := range toSend {
+					if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+						t.Errorf("serialise failed: %v", err)
+					}
+				}
+				// Receive
+				for i := range toRecv {
+					if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+						t.Errorf("deserialise failed: %v", err)
+					}
+				}
+				if want, got := len(toSend), len(toRecv); want != got {
+					t.Errorf("mismatch: sent %d items but received %d", want, got)
+				}
+				for i := range toSend {
+					if want, got := toSend[i], toRecv[i]; want != got {
+						t.Errorf("mismatch at %d: sent %#v but got %#v", i, want, got)
+					}
+				}
+			})
+		}
+	})
+	t.Run("byte", func(t *testing.T) {
+		toSend := []byte("abc")
+		toRecv := make([]byte, 3)
+
+		for _, transport := range transports {
+			t.Run(transport.name, func(t *testing.T) {
+				mpc := mockMPChan(transport.sFmt)
+				// Send
+				for i := range toSend {
+					if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+						t.Errorf("serialise failed: %v", err)
+					}
+				}
+				// Receive
+				for i := range toRecv {
+					if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+						t.Errorf("deserialise failed: %v", err)
+					}
+				}
+				if want, got := len(toSend), len(toRecv); want != got {
+					t.Errorf("mismatch: sent %d items but received %d", want, got)
+				}
+				for i := range toSend {
+					if want, got := toSend[i], toRecv[i]; want != got {
+						t.Errorf("mismatch at %d: sent %#v but got %#v", i, want, got)
+					}
+				}
+			})
+		}
+	})
+	t.Run("string", func(t *testing.T) {
+		toSend := []string{"AAA", "BBB", "CCC"}
+		toRecv := make([]string, 3)
+		toRecv[0] = "D"
+		toRecv[1] = "EEE"
+		toRecv[2] = "FF"
+
+		for _, transport := range transports {
+			t.Run(transport.name, func(t *testing.T) {
+				mpc := mockMPChan(transport.sFmt)
+				// Send
+				for i := range toSend {
+					if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+						t.Errorf("serialise failed: %v", err)
+					}
+				}
+				// Receive
+				for i := range toRecv {
+					if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+						t.Errorf("deserialise failed: %v", err)
+					}
+				}
+				if want, got := len(toSend), len(toRecv); want != got {
+					t.Errorf("mismatch: sent %d items but received %d", want, got)
+				}
+				for i := range toSend {
+					if want, got := toSend[i], toRecv[i]; want != got {
+						t.Errorf("mismatch at %d: sent %#v but got %#v", i, want, got)
+					}
+				}
+			})
+		}
+	})
 }
 
 // This covers the cases when the message is of format: Label(StructType)

--- a/runtime/session2/message_test.go
+++ b/runtime/session2/message_test.go
@@ -3,7 +3,6 @@ package session2
 import (
 	"bytes"
 	"encoding/gob"
-	"io"
 	"testing"
 )
 
@@ -15,11 +14,11 @@ type fakeChan struct {
 func newFakeChan(N int) *fakeChan {
 	return &fakeChan{new(bytes.Buffer), make(chan interface{}, N)}
 }
-func (c *fakeChan) GetReader() io.Reader       { return c.buf }
-func (c *fakeChan) GetWriter() io.Writer       { return c.buf }
-func (c *fakeChan) Close() error               { return nil }
-func (c *fakeChan) ReadPointer(m *interface{}) { *m = <-c.ptr }
-func (c *fakeChan) WritePointer(m interface{}) { c.ptr <- m }
+func (c *fakeChan) Read(p []byte) (int, error)  { return c.buf.Read(p) }
+func (c *fakeChan) Write(p []byte) (int, error) { return c.buf.Write(p) }
+func (c *fakeChan) Close() error                { return nil }
+func (c *fakeChan) ReadPointer(m *interface{})  { *m = <-c.ptr }
+func (c *fakeChan) WritePointer(m interface{})  { c.ptr <- m }
 
 func mockMPChan(fmtr ScribMessageFormatter) *MPChan {
 	mpc := NewMPChan(0, []string{""})

--- a/runtime/transport2/shm/shm.go
+++ b/runtime/transport2/shm/shm.go
@@ -69,9 +69,6 @@ func (c *Channel) Close() error {
 	return nil
 }
 
-func (c *Channel) GetReader() io.Reader { return c }
-func (c *Channel) GetWriter() io.Writer { return c }
-
 // ReadPointer is for receiving pointer over an untyped channel.
 func (c *Channel) ReadPointer(m *interface{}) {
 	*m = <-c.rdPtr

--- a/runtime/transport2/shm/shm.go
+++ b/runtime/transport2/shm/shm.go
@@ -1,8 +1,8 @@
+// Package shm provides a shared memory transport implementation.
 package shm
 
 import (
 	"fmt"
-	"io"
 	"sync"
 
 	"github.com/rhu1/scribble-go-runtime/runtime/transport2"
@@ -64,7 +64,7 @@ func (c *Channel) Write(b []byte) (n int, err error) {
 	return n, nil
 }
 
-// Close channel terminates a channel.
+// Close terminates a channel.
 func (c *Channel) Close() error {
 	return nil
 }
@@ -82,13 +82,15 @@ func (c *Channel) WritePointer(m interface{}) {
 	c.wrPtr <- m
 }
 
-// Listener is a server-side shared memory listener
+// ShmListener is a server-side shared memory listener
 // which implements transport.ScribListener.
 type ShmListener struct {
 	port int
 	ch   *sharedChan
 }
 
+// Accept waits for and accepts incoming connection.
+// It blocks until connection is established.
 func (ln *ShmListener) Accept() (transport2.BinChannel, error) {
 	c := Channel{
 		rdRx: ln.ch.cb1, rdTx: ln.ch.cn1, rdPtr: ln.ch.cp1,
@@ -98,6 +100,10 @@ func (ln *ShmListener) Accept() (transport2.BinChannel, error) {
 	return &c, nil
 }
 
+// Close terminates a listening shm connection.
+//
+// The port the listener is listening on is freed
+// and available again after a Close.
 func (ln *ShmListener) Close() error {
 	ports.mu.Lock()
 	defer ports.mu.Unlock()
@@ -128,7 +134,7 @@ func init() {
 	}
 }
 
-// Listen creates a new listener at with port as identifier.
+// Listen creates a new listener at port.
 func Listen(port int) (*ShmListener, error) {
 	ports.mu.Lock()
 	defer ports.mu.Unlock()
@@ -140,11 +146,14 @@ func Listen(port int) (*ShmListener, error) {
 	return &ShmListener{port: port, ch: shared}, nil
 }
 
+// BListen creates a new listener at port.
+//
 // FIXME HACK -- simply replace existing Listen signature with this one?
 func BListen(port int) (transport2.ScribListener, error) {
-	return Listen(port)	
+	return Listen(port)
 }
 
+// Dial uses the given port to establish a shm connection.
 func Dial(_ string, port int) (transport2.BinChannel, error) {
 	ports.mu.Lock()
 	defer ports.mu.Unlock()

--- a/runtime/transport2/shm/shm_test.go
+++ b/runtime/transport2/shm/shm_test.go
@@ -23,12 +23,12 @@ func TestRoundTrip(t *testing.T) {
 		}
 		r := bytes.NewReader(input)
 		inputLen := int64(len(input))
-		n, err := io.CopyN(server.GetWriter(), r, inputLen) // message to server
+		n, err := io.CopyN(server, r, inputLen) // message to server
 		if err != nil {
 			t.Error(err)
 		}
 		t.Logf("Server received %d bytes", n)
-		n, err = io.CopyN(server.GetWriter(), server.GetReader(), inputLen) // server to client
+		n, err = io.CopyN(server, server, inputLen) // server to client
 		if err != nil {
 			t.Error(err)
 		}
@@ -40,13 +40,13 @@ func TestRoundTrip(t *testing.T) {
 	}
 
 	inputLen := int64(len(input))
-	n, err := io.CopyN(client.GetWriter(), client.GetReader(), inputLen)
+	n, err := io.CopyN(client, client, inputLen)
 	if err != nil {
 		t.Error(err)
 	}
 	t.Logf("Client forwarded %d bytes", n)
 	var b bytes.Buffer
-	n, err = io.CopyN(&b, client.GetReader(), inputLen)
+	n, err = io.CopyN(&b, client, inputLen)
 	if err != nil {
 		t.Error(err)
 	}

--- a/runtime/transport2/tcp/tcp.go
+++ b/runtime/transport2/tcp/tcp.go
@@ -1,30 +1,25 @@
+// Package tcp provides a TCP transport implementation.
 package tcp
 
 import (
-	//"bufio"
-	//"errors"
-	"fmt"
-	"io"
 	"log"
-	//"log"
+
 	"net"
 	"strconv"
-	//"sync"
-	//"time"
 
 	"github.com/rhu1/scribble-go-runtime/runtime/transport2"
 )
 
-var _ = fmt.Print
-
-// Wrapper for "tcp" net.Listener
+// TcpListener is a server-side TCP listener
+// which implements transport.ScribListener.
+// It wraps the standard library "net".Listener.
 type TcpListener struct {
-	port net.Listener	
+	ln net.Listener
 }
 
-//func (ss *TcpListener) Accept() (*TcpChannel, error) {
+// Accept waits for and accepts incoming connection.
 func (ss *TcpListener) Accept() (transport2.BinChannel, error) {
-	conn, err := ss.port.Accept()
+	conn, err := ss.ln.Accept()
 	if err != nil {
 		log.Fatalf("cannot accept %s: %v", ss.Addr().String(), err)
 	}
@@ -34,32 +29,33 @@ func (ss *TcpListener) Accept() (transport2.BinChannel, error) {
 
 // Addr returns the listener's network address.
 func (ss *TcpListener) Addr() net.Addr {
-	return ss.port.Addr()
+	return ss.ln.Addr()
 }
 
+// Close terminates a listening TCP listener.
 func (ss *TcpListener) Close() error {
-	return ss.port.Close()
+	return ss.ln.Close()
 }
 
-/*type Tcp struct {
-	
-}*/
-
+// Listen creates a new TCP listener at port port.
+// The running user needs to be a privileged user for port <= 1024.
 func Listen(port int) (*TcpListener, error) {
-	p, err := net.Listen("tcp", "localhost:"+strconv.Itoa(port))
+	ln, err := net.Listen("tcp", "localhost:"+strconv.Itoa(port))
 	if err != nil {
 		log.Fatalf("cannot listen at :%d: %v", port, err)
 	}
-	ss := TcpListener{port: p}
+	ss := TcpListener{ln: ln}
 	return &ss, err
 }
 
+// BListen creates a new TCP listener at port.
+//
 // FIXME HACK -- simply replace existing Listen signature with this one?
 func BListen(port int) (transport2.ScribListener, error) {
 	return Listen(port)
 }
 
-//func Dial(host string, port int) (*TcpChannel, error) {
+// Dial uses the given port to establish a TCP connection.
 func Dial(host string, port int) (transport2.BinChannel, error) {
 	conn, err := net.Dial("tcp", host+":"+strconv.Itoa(port))
 	if err != nil {
@@ -69,9 +65,10 @@ func Dial(host string, port int) (transport2.BinChannel, error) {
 	return &c, err
 }
 
-// Wrapper for "tcp" net.Conn
+// TcpChannel is a binary channel over TCP.
+// It is implemented as a wrapper to standard library "net".Conn.
 type TcpChannel struct {
-	conn net.Conn 	
+	conn net.Conn
 }
 
 /*func (c *TcpChannel) GetConn() net.Conn {
@@ -85,238 +82,7 @@ func (c *TcpChannel) GetWriter() io.Writer {
 	return c.conn
 }
 
-/*func (c *TcpChannel) Write(bs []byte) error {
-	n, err := c.conn.Write(bs)
-	if len(bs) != n {
-		panic("[tcp] FIXME: write fully: ")	
-	}
-	return err
-}
-
-// Read fully
-func (c *TcpChannel) Read(bs []byte) error {
-	n, err := c.conn.Read(bs)
-	if len(bs) != n {
-		panic("[tcp] FIXME: read fully: ")	
-	}
-	return err
-}*/
-
+// Close terminates a TCP channel.
 func (c *TcpChannel) Close() error {
 	return c.conn.Close()
 }
-
-
-
-/*var (
-	ErrCloseUnfinishedConn = errors.New("transport/tcp: closing connection with unread data")
-)
-
-// SerialisationError is the kind of error where a value
-// cannot be sent due to serialisation failure.
-type SerialisationError struct {
-	cause error
-}
-
-func (e SerialisationError) Error() string {
-	return fmt.Sprintf("transport/tcp send: serialisation failed: %v", e.cause)
-}
-
-// DeserialisationError is the kind of error where a value
-// cannot be received due to deserialisation failure.
-type DeserialisationError struct {
-	cause error
-}
-
-func (e DeserialisationError) Error() string {
-	return fmt.Sprintf("transport/tcp recv: deserisalisation failed: %v", e.cause)
-}
-
-// ConnCfg is a connection configuration, contains
-// the details required to establish a connection.
-type ConnCfg struct {
-	Host string
-	Port string
-
-	// DelimMeth specifies delimiter implementation.
-	DelimMeth     DelimitMethod
-	SerialiseMeth SerialiseMethod
-
-	// retryWait specifies the time to wait before retrying connection.
-	retryWait time.Duration
-}
-
-// NewConnection is a convenient wrapper for a TCP connection
-// and can be used as either server-side or client-side.
-func NewConnection(host, port string) ConnCfg {
-	return ConnCfg{Host: host, Port: port}
-}
-
-func Listen(port string) ConnCfg {
-	return NewConnection("__dummy", port)
-}
-
-func NewAcceptor(port string) ConnCfg {
-	return NewConnection("__dummy", port)
-}
-
-func NewRequestor(host string, port string) ConnCfg {
-	return NewConnection(host, port)
-}
-
-func NewConnectionWithRetry(host, port string, retryWait time.Duration) ConnCfg {
-	return ConnCfg{Host: host, Port: port, retryWait: retryWait}
-}
-
-// Accept listens for and accepts connection from a TCP socket using
-// details from cfg, and returns the TCP stream as a ReadWriteCloser.
-//
-// Accept blocks while waiting for connection to be accepted.
-func (cfg ConnCfg) Accept() transport.Channel {
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%s", cfg.Port))  // FIXME: port should be opened on Listen, not Accept
-	if err != nil {
-		log.Fatalf("cannot listen at :%s: %v", cfg.Port, err)
-	}
-	conn, err := ln.Accept()
-	if err != nil {
-		log.Fatalf("cannot accept connection at :%s: %v", cfg.Port, err)
-	}
-	return cfg.newConn(conn)
-}
-
-// Connect establishes a connection with a TCP socket using details
-// from cfg, and returns the TCP stream as a ReadWriteCloser.
-func (cfg ConnCfg) Connect() transport.Channel {
-	addr := net.JoinHostPort(cfg.Host, cfg.Port)
-	conn, err := net.Dial("tcp", addr)
-	if err != nil {
-		if cfg.retryWait > 0 {
-			time.Sleep(cfg.retryWait)
-			cfg.retryWait = 0
-			return cfg.Connect()
-		}
-		log.Fatalf("cannot connect to %s: %v", addr, err)
-	}
-	return cfg.newConn(conn)
-}
-
-func (cfg ConnCfg) Request() transport.Channel {
-	return cfg.Connect()
-}
-
-func (cfg ConnCfg) newConn(rwc net.Conn) *Conn {
-	c := &Conn{
-		rwc: rwc,
-	}
-	c.rdMu.Lock()
-	c.bufr = newReader(c.rwc)
-	c.dec = NewDeserialiser(NewDelimReader(c, cfg.DelimMeth), cfg.SerialiseMeth)
-	c.rdMu.Unlock()
-
-	c.wtMu.Lock()
-	c.bufw = newWriter(c.rwc)
-	c.enc = NewSerialiser(NewDelimWriter(c, cfg.DelimMeth), cfg.SerialiseMeth)
-	c.wtMu.Unlock()
-	return c
-}
-
-// Conn is a connected TCP stream/connection, and wraps a net.Conn created
-// by either Accept or Connect.
-//
-// Conn implements ReadWriteCloser and can be used as is, more fine-grained
-// message formatting control (such as delimited multi messages) should use
-// NewSizedReader/SizedWriter (message with size prefix) or
-// NewDelimReader/DelimWriter (delimited message).
-type Conn struct {
-	// rwc is the real TCP connection.
-	rwc net.Conn
-
-	// guards the read buffer and the decoder
-	rdMu sync.Mutex
-
-	bufr *bufio.Reader // bufr is a buffered stream to the TCP connection.
-	dec  deserialiser  // dec is a serialisation decoder for messages from rwc.
-
-	// guards the write buffer and the encoder
-	wtMu sync.Mutex
-
-	bufw *bufio.Writer // bufw is a buffered stream to the TCP connection.
-	enc  serialiser    // enc is a serialisation encoder for messages to rwc.
-}
-
-// newReader returns a fresh buffered Reader.
-func newReader(r io.Reader) *bufio.Reader {
-	// TODO(nickng): use sync.Pool to reduce allocation per new connection.
-	return bufio.NewReader(r)
-}
-
-// newWriter returns a fresh buffered Writer.
-func newWriter(w io.Writer) *bufio.Writer {
-	// TODO(nickng): use sync.Pool to reduce allocation per new connection.
-	return bufio.NewWriter(w)
-}
-
-// Read reads data into p. It returns the number of bytes read into p. The
-// bytes are taken from at most one Read on the underlying Reader, hence n
-// may be less than len(p). At EOF, the count will be zero and err will be
-// io.EOF.
-//
-// The underlying implementation is a *bufio.Reader.
-func (c *Conn) Read(p []byte) (n int, err error) {
-	return c.bufr.Read(p)
-}
-
-// Writer writes the content of p into the underlying stream. It returns
-// the number of bytes written. If n < len(p), it also returns an error
-// explaining why the write is short.
-//
-// The underlying implementation is a *bufio.Writer, and data will be
-// flushed whenever Write is called.
-func (c *Conn) Write(p []byte) (n int, err error) {
-	n, err = c.bufw.Write(p)
-	c.bufw.Flush()
-	return n, err
-}
-
-func (c *Conn) ScribWrite(bs []byte) error {
-	return nil
-}
-
-func (c *Conn) ScribRead(bs *[]byte) error {
-	return nil	
-}
-
-// Close closes the underlying TCP connection.
-func (c *Conn) Close() error {
-	if c.bufw.Available() > 0 {
-		c.bufw.Flush()
-	}
-	if c.bufr.Buffered() > 0 {
-		c.rwc.Close()
-		return ErrCloseUnfinishedConn
-	}
-	return c.rwc.Close()
-}
-
-// Send serialises values val then sends the serialised
-// values to the underlying stream of connection c.
-func (c *Conn) Send(val interface{}) error {
-	c.wtMu.Lock()
-	defer c.wtMu.Unlock()
-	if err := c.enc.Encode(val); err != nil {
-		return SerialisationError{cause: err}
-	}
-	return nil
-}
-
-// Recv receives values from the underlying stream then deserialises and
-// writes the deserialised values to the pointer addresses specified by ptr.
-func (c *Conn) Recv(ptr interface{}) error {
-	c.rdMu.Lock()
-	defer c.rdMu.Unlock()
-	if err := c.dec.Decode(ptr); err != nil {
-		return DeserialisationError{cause: err}
-	}
-	return nil
-}
-*/

--- a/runtime/transport2/tcp/tcp.go
+++ b/runtime/transport2/tcp/tcp.go
@@ -71,15 +71,12 @@ type TcpChannel struct {
 	conn net.Conn
 }
 
-/*func (c *TcpChannel) GetConn() net.Conn {
-	return c.conn
-}*/
-func (c *TcpChannel) GetReader() io.Reader {
-	return c.conn
+func (c *TcpChannel) Read(b []byte) (n int, err error) {
+	return c.conn.Read(b)
 }
 
-func (c *TcpChannel) GetWriter() io.Writer {
-	return c.conn
+func (c *TcpChannel) Write(b []byte) (n int, err error) {
+	return c.conn.Write(b)
 }
 
 // Close terminates a TCP channel.

--- a/runtime/transport2/transport2.go
+++ b/runtime/transport2/transport2.go
@@ -2,19 +2,17 @@ package transport2
 
 import (
 	"io"
-	//"net"
 )
 
-/*type Transport interface {
-	Listen(int)	(ScribListener, error)
-	Dial(string, int) (BinChannel, error)
-}*/
-
+// ScribListener is a generic Listener
+// implemented by all Scribble transports.
 type ScribListener interface {
 	Accept() (BinChannel, error)
 	Close() error
 }
 
+// BinChannel is a generic binary channel
+// implemented by all Scribble transports.
 type BinChannel interface {
 	//io.Closer
 

--- a/runtime/transport2/transport2.go
+++ b/runtime/transport2/transport2.go
@@ -14,13 +14,7 @@ type ScribListener interface {
 // BinChannel is a generic binary channel
 // implemented by all Scribble transports.
 type BinChannel interface {
-	//io.Closer
-
-	// Conn implements the Reader and Writer interfaces -- can use with gob
-	//GetConn() net.Conn
-	GetReader() io.Reader	
-	GetWriter() io.Writer	
-	/*Write(bs []byte) error
-	Read(bs []byte) error  // Read fully*/
-	Close() error
+	// ReadWriteCloser is the standard binary channel interface in Go.
+	// It contains Read/Write/Close method.
+	io.ReadWriteCloser
 }


### PR DESCRIPTION
GoDoc-ready documentation for runtime, minor internal changes to the runtime interfaces.

## Internal changes

Instead of requiring transports to use Java-style getter method on *interfaces*

    GetReader() io.Reader
    GetWriter() io.Writer

Change to Go-style interfaces, where all transports should directly implement methods in `io.Writer` and `io.Reader`, i.e.,

    Read(b []byte) (n int, err error)
    Write(b []byte) (n int, err error)

which are provided by `net.Conn`. The wrapper only need to call into `conn.Read` and `conn.Write`. If `Read` and `Write` are from separate `conn`s, simply proxy the `Read` `Write` function to the different `conn`s to preserve the flexibility of `GetReader` `GetWriter`