### PR TITLE
Various small fixes for twodim package.

### DIFF
--- a/runtime/twodim/session2/message_test.go
+++ b/runtime/twodim/session2/message_test.go
@@ -21,8 +21,8 @@ func (c *fakeChan) ReadPointer(m *interface{})  { *m = <-c.ptr }
 func (c *fakeChan) WritePointer(m interface{})  { c.ptr <- m }
 
 func mockMPChan(fmtr ScribMessageFormatter) *MPChan {
-	mpc := NewMPChan(0, []string{""})
-	mpc.Fmts[""][0] = fmtr
+	mpc := NewMPChan(XY(0, 0), []string{""})
+	mpc.Fmts[""][XY(0, 0)] = fmtr
 	return mpc
 }
 
@@ -57,13 +57,13 @@ func TestSerialisePrimitiveType(t *testing.T) {
 				mpc := mockMPChan(transport.sFmt)
 				// Send
 				for i := range toSend {
-					if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+					if err := mpc.ISend("", XY(0, 0), &toSend[i]); err != nil {
 						t.Errorf("serialise failed: %v", err)
 					}
 				}
 				// Receive
 				for i := range toRecv {
-					if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+					if err := mpc.IRecv("", XY(0, 0), &toRecv[i]); err != nil {
 						t.Errorf("deserialise failed: %v", err)
 					}
 				}
@@ -87,13 +87,13 @@ func TestSerialisePrimitiveType(t *testing.T) {
 				mpc := mockMPChan(transport.sFmt)
 				// Send
 				for i := range toSend {
-					if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+					if err := mpc.ISend("", XY(0, 0), &toSend[i]); err != nil {
 						t.Errorf("serialise failed: %v", err)
 					}
 				}
 				// Receive
 				for i := range toRecv {
-					if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+					if err := mpc.IRecv("", XY(0, 0), &toRecv[i]); err != nil {
 						t.Errorf("deserialise failed: %v", err)
 					}
 				}
@@ -117,13 +117,13 @@ func TestSerialisePrimitiveType(t *testing.T) {
 				mpc := mockMPChan(transport.sFmt)
 				// Send
 				for i := range toSend {
-					if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+					if err := mpc.ISend("", XY(0, 0), &toSend[i]); err != nil {
 						t.Errorf("serialise failed: %v", err)
 					}
 				}
 				// Receive
 				for i := range toRecv {
-					if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+					if err := mpc.IRecv("", XY(0, 0), &toRecv[i]); err != nil {
 						t.Errorf("deserialise failed: %v", err)
 					}
 				}
@@ -150,13 +150,13 @@ func TestSerialisePrimitiveType(t *testing.T) {
 				mpc := mockMPChan(transport.sFmt)
 				// Send
 				for i := range toSend {
-					if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+					if err := mpc.ISend("", XY(0, 0), &toSend[i]); err != nil {
 						t.Errorf("serialise failed: %v", err)
 					}
 				}
 				// Receive
 				for i := range toRecv {
-					if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+					if err := mpc.IRecv("", XY(0, 0), &toRecv[i]); err != nil {
 						t.Errorf("deserialise failed: %v", err)
 					}
 				}
@@ -191,13 +191,13 @@ func TestSerialiseStructType(t *testing.T) {
 			gob.Register(new(StructType)) // Register type
 			// Send
 			for i := range toSend {
-				if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+				if err := mpc.ISend("", XY(0, 0), &toSend[i]); err != nil {
 					t.Errorf("serialise failed: %v", err)
 				}
 			}
 			// Receive
 			for i := range toRecv {
-				if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+				if err := mpc.IRecv("", XY(0, 0), &toRecv[i]); err != nil {
 					t.Errorf("deserialise failed: %v", err)
 				}
 			}
@@ -229,13 +229,13 @@ func TestSerialiseNamedSig(t *testing.T) {
 			gob.Register(new(NamedSig)) // Register type
 			// Send
 			for i := range toSend {
-				if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+				if err := mpc.ISend("", XY(0, 0), &toSend[i]); err != nil {
 					t.Errorf("serialise failed: %v", err)
 				}
 			}
 			// Receive
 			for i := range toRecv {
-				if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+				if err := mpc.IRecv("", XY(0, 0), &toRecv[i]); err != nil {
 					t.Errorf("deserialise failed: %v", err)
 				}
 			}
@@ -269,13 +269,13 @@ func TestSerialiseStructSig(t *testing.T) {
 			gob.Register(new(StructSig)) // Register type
 			// Send
 			for i := range toSend {
-				if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+				if err := mpc.ISend("", XY(0, 0), &toSend[i]); err != nil {
 					t.Errorf("serialise failed: %v", err)
 				}
 			}
 			// Receive
 			for i := range toRecv {
-				if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+				if err := mpc.IRecv("", XY(0, 0), &toRecv[i]); err != nil {
 					t.Errorf("deserialise failed: %v", err)
 				}
 			}
@@ -318,13 +318,13 @@ func TestSerialiseStructPtrFieldSig(t *testing.T) {
 			gob.Register(new(StructPtrFieldSig)) // Register type
 			// Send
 			for i := range toSend {
-				if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+				if err := mpc.ISend("", XY(0, 0), &toSend[i]); err != nil {
 					t.Errorf("serialise failed: %v", err)
 				}
 			}
 			// Receive
 			for i := range toRecv {
-				if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+				if err := mpc.IRecv("", XY(0, 0), &toRecv[i]); err != nil {
 					t.Errorf("deserialise failed: %v", err)
 				}
 			}
@@ -354,13 +354,13 @@ func TestSerialisePtrPrimitiveSig(t *testing.T) {
 			mpc := mockMPChan(transport.sFmt)
 			// Send
 			for i := range toSend {
-				if err := mpc.ISend("", 0, &toSend[i]); err != nil {
+				if err := mpc.ISend("", XY(0, 0), &toSend[i]); err != nil {
 					t.Errorf("serialise failed: %v", err)
 				}
 			}
 			// Receive
 			for i := range toRecv {
-				if err := mpc.IRecv("", 0, &toRecv[i]); err != nil {
+				if err := mpc.IRecv("", XY(0, 0), &toRecv[i]); err != nil {
 					t.Errorf("deserialise failed: %v", err)
 				}
 			}
@@ -373,5 +373,13 @@ func TestSerialisePtrPrimitiveSig(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPairEquality(t *testing.T) {
+	if a, b := XY(0, 0), XY(0, 0); a != b {
+		t.Fatalf("%v != %v.\n", a, b)
+	} else {
+		t.Logf("%v == %v.\n", a, b)
 	}
 }

--- a/runtime/twodim/session2/pair.go
+++ b/runtime/twodim/session2/pair.go
@@ -13,26 +13,32 @@ func XY(x, y int) Pair {
 }
 
 func (p1 Pair) Lte(p2 Pair) bool {
-	return p1.X <= p2.X && p1.Y <= p2.Y;	
+	return p1.X <= p2.X && p1.Y <= p2.Y
 }
 
 func (p Pair) Inc(max Pair) Pair {
-	if 	p.Y < max.Y {
-		return XY(p.X, p.Y+1)	
-	} else {//if p.Y < max.Y {
-		return XY(p.X+1, 1)	
-	} /*else {
-		panic("Bad inc:")  // Inconvenient in for-loops
-	}*/
+	if p.Y < max.Y {
+		return XY(p.X, p.Y+1)
+	} else {
+		return XY(p.X+1, 1)
+	}
 }
 
-// Assumes base default is (1, 1), and count (1,1), (1,2), (1,3), ..., (2,1), ...
+// Flatten converts p into an ordinal number.
+//
+// Couting starts from (1,1) and stays within
+// the bounds of (1,1) and max. An example of
+// counting order is:
+//
+// (1,1), (1,2), (1,3), ..., (2,1), ...
+//
 func (p Pair) Flatten(max Pair) int {
-	return ((p.X-1) * max.Y) + p.Y;
+	return ((p.X - 1) * max.Y) + p.Y
 }
 
-func (p Pair) Tostring() string {
-	return "(" + strconv.Itoa(p.X) + ", " + strconv.Itoa(p.Y) + ")";
+// String returns the string representation.
+func (p Pair) String() string {
+	return "(" + strconv.Itoa(p.X) + ", " + strconv.Itoa(p.Y) + ")"
 }
 
 func (p1 Pair) Plus(p2 Pair) Pair {

--- a/test/hadamard/main.go
+++ b/test/hadamard/main.go
@@ -162,8 +162,8 @@ func client_C(wg *sync.WaitGroup, K session2.Pair, self session2.Pair) *C.End {
 func runC(c *C.Init) C.End {
 	pay := make([]message.Val, 1)
 	c2 := c.A_selfplusl0r0_Gather_Val(pay)
-	fmt.Println("C(" + c.Ept.Self.Tostring() + ") received from A:", pay)
+	fmt.Println("C("+c.Ept.Self.String()+") received from A:", pay)
 	end := c2.B_selfplusl0r0_Gather_Val(pay)
-	fmt.Println("C(" + c.Ept.Self.Tostring() + ") received from B:", pay)
+	fmt.Println("C("+c.Ept.Self.String()+") received from B:", pay)
 	return *end
 }

--- a/test/mesh/mesh01/main.go
+++ b/test/mesh/mesh01/main.go
@@ -10,15 +10,16 @@ import (
 	"encoding/gob"
 	"fmt"
 	"log"
+
 	//"math/rand"
 	//"strconv"
 	"sync"
 	"time"
 
-	"github.com/rhu1/scribble-go-runtime/runtime/twodim/session2"
 	"github.com/rhu1/scribble-go-runtime/runtime/transport2"
 	"github.com/rhu1/scribble-go-runtime/runtime/transport2/shm"
 	"github.com/rhu1/scribble-go-runtime/runtime/transport2/tcp"
+	"github.com/rhu1/scribble-go-runtime/runtime/twodim/session2"
 
 	"github.com/rhu1/scribble-go-runtime/test/mesh/mesh01/Mesh1/Proto1"
 	B "github.com/rhu1/scribble-go-runtime/test/mesh/mesh01/Mesh1/Proto1/family_1/W_l1r1toKhwsubl1r0_not_l2r1toKhw"
@@ -98,8 +99,8 @@ func server_T(wg *sync.WaitGroup, Khw session2.Pair, self session2.Pair) *T.End 
 
 func runT(s *T.Init) T.End {
 	pay := make([]string, 1)
-	end := s.W_selfpluslneg1r0_Gather_Foo(pay);
-	fmt.Println("T(" + s.Ept.Self.Tostring() + ") gathered Foo:", pay)
+	end := s.W_selfpluslneg1r0_Gather_Foo(pay)
+	fmt.Println("T("+s.Ept.Self.String()+") gathered Foo:", pay)
 	return *end
 }
 
@@ -153,11 +154,11 @@ func server_M(wg *sync.WaitGroup, Khw session2.Pair, self session2.Pair) *M.End 
 
 func runM(s *M.Init) M.End {
 	pay := make([]string, 1)
-	s2 := s.W_selfpluslneg1r0_Gather_Foo(pay);
-	fmt.Println("M(" + s.Ept.Self.Tostring() + ") gathered Foo:", pay)
-	pay = []string{pay[0] + "thenM" + s.Ept.Self.Tostring()}
+	s2 := s.W_selfpluslneg1r0_Gather_Foo(pay)
+	fmt.Println("M("+s.Ept.Self.String()+") gathered Foo:", pay)
+	pay = []string{pay[0] + "thenM" + s.Ept.Self.String()}
 	end := s2.W_selfplusl1r0_Scatter_Foo(pay)
-	fmt.Println("M(" + s.Ept.Self.Tostring() + ") scattered Foo:", pay)
+	fmt.Println("M("+s.Ept.Self.String()+") scattered Foo:", pay)
 	return *end
 }
 
@@ -177,8 +178,8 @@ func client_B(wg *sync.WaitGroup, Khw session2.Pair, self session2.Pair) *B.End 
 }
 
 func runB(s *B.Init) B.End {
-	pay := []string{"B" + s.Ept.Self.Tostring()}
+	pay := []string{"B" + s.Ept.Self.String()}
 	end := s.W_selfplusl1r0_Scatter_Foo(pay)
-	fmt.Println("B(" + s.Ept.Self.Tostring() + ") scattered Foo:", pay)
+	fmt.Println("B("+s.Ept.Self.String()+") scattered Foo:", pay)
 	return *end
 }

--- a/test/mesh/mesh02/main.go
+++ b/test/mesh/mesh02/main.go
@@ -8,15 +8,16 @@ import (
 	"encoding/gob"
 	"fmt"
 	"log"
+
 	//"math/rand"
 	//"strconv"
 	"sync"
 	"time"
 
-	"github.com/rhu1/scribble-go-runtime/runtime/twodim/session2"
 	"github.com/rhu1/scribble-go-runtime/runtime/transport2"
 	"github.com/rhu1/scribble-go-runtime/runtime/transport2/shm"
 	"github.com/rhu1/scribble-go-runtime/runtime/transport2/tcp"
+	"github.com/rhu1/scribble-go-runtime/runtime/twodim/session2"
 
 	"github.com/rhu1/scribble-go-runtime/test/mesh/mesh02/Mesh2/Proto3"
 	L "github.com/rhu1/scribble-go-runtime/test/mesh/mesh02/Mesh2/Proto3/family_1/W_l1r1toK1wsubl0r1_not_l1r2toK1w"
@@ -96,8 +97,8 @@ func server_R(wg *sync.WaitGroup, K1w session2.Pair, self session2.Pair) *R.End 
 
 func runR(s *R.Init) R.End {
 	pay := make([]string, 1)
-	end := s.W_selfplusl0rneg1_Gather_Foo(pay);
-	fmt.Println("R(" + s.Ept.Self.Tostring() + ") gathered Foo:", pay)
+	end := s.W_selfplusl0rneg1_Gather_Foo(pay)
+	fmt.Println("R("+s.Ept.Self.String()+") gathered Foo:", pay)
 	return *end
 }
 
@@ -151,14 +152,13 @@ func server_M(wg *sync.WaitGroup, K1w session2.Pair, self session2.Pair) *M.End 
 
 func runM(s *M.Init) M.End {
 	pay := make([]string, 1)
-	s2 := s.W_selfplusl0rneg1_Gather_Foo(pay);
-	fmt.Println("M(" + s.Ept.Self.Tostring() + ") gathered Foo:", pay)
-	pay = []string{pay[0] + "thenM" + s.Ept.Self.Tostring()}
+	s2 := s.W_selfplusl0rneg1_Gather_Foo(pay)
+	fmt.Println("M("+s.Ept.Self.String()+") gathered Foo:", pay)
+	pay = []string{pay[0] + "thenM" + s.Ept.Self.String()}
 	end := s2.W_selfplusl0r1_Scatter_Foo(pay)
-	fmt.Println("M(" + s.Ept.Self.Tostring() + ") scattered Foo:", pay)
+	fmt.Println("M("+s.Ept.Self.String()+") scattered Foo:", pay)
 	return *end
 }
-
 
 // self.Y == 1
 func client_L(wg *sync.WaitGroup, K1w session2.Pair, self session2.Pair) *L.End {
@@ -175,8 +175,8 @@ func client_L(wg *sync.WaitGroup, K1w session2.Pair, self session2.Pair) *L.End 
 }
 
 func runL(s *L.Init) L.End {
-	pay := []string{"L" + s.Ept.Self.Tostring()}
+	pay := []string{"L" + s.Ept.Self.String()}
 	end := s.W_selfplusl0r1_Scatter_Foo(pay)
-	fmt.Println("L(" + s.Ept.Self.Tostring() + ") scattered Foo:", pay)
+	fmt.Println("L("+s.Ept.Self.String()+") scattered Foo:", pay)
 	return *end
 }

--- a/test/pair/pair01/main.go
+++ b/test/pair/pair01/main.go
@@ -112,6 +112,6 @@ func clientCode(wg *sync.WaitGroup, p11 session2.Pair) *W11.End {
 func runW(w *W11.Init) W11.End {
 	data := make([]int, 1)
 	end := w.S_l1r1_Gather_Foo(data)
-	fmt.Println("W(" + w.Ept.Self.Tostring() + ") gathered:", data)
+	fmt.Println("W("+w.Ept.Self.String()+") gathered:", data)
 	return *end
 }

--- a/test/pair/pair02/main.go
+++ b/test/pair/pair02/main.go
@@ -113,7 +113,7 @@ func clientCode(wg *sync.WaitGroup, K session2.Pair, self session2.Pair) *W11_K.
 
 func runW(w *W11_K.Init) W11_K.End {
 	data := make([]int, 1)
-	end := w.S_l1r1_Gather_Foo(data)  // FIXME: panic: interface conversion: interface {} is int, not *int -- cf. gob.Register in commented init() ?
-	fmt.Println("W(" + w.Ept.Self.Tostring() + ") gathered:", data)
+	end := w.S_l1r1_Gather_Foo(data) // FIXME: panic: interface conversion: interface {} is int, not *int -- cf. gob.Register in commented init() ?
+	fmt.Println("W("+w.Ept.Self.String()+") gathered:", data)
 	return *end
 }

--- a/test/pair/pair03/main.go
+++ b/test/pair/pair03/main.go
@@ -125,11 +125,11 @@ func runW(w *W11_K.Init) W11_K.End {
 	case *W11_K.Foo:
 		var x int
 		end = c.Recv_Foo(&x)
-		fmt.Println("W(" + w.Ept.Self.Tostring() + ") received Foo:", x)
-	case *W11_K.Bar: 
+		fmt.Println("W("+w.Ept.Self.String()+") received Foo:", x)
+	case *W11_K.Bar:
 		var x string
 		end = c.Recv_Bar(&x)
-		fmt.Println("W(" + w.Ept.Self.Tostring() + ") received Bar:", x)
+		fmt.Println("W("+w.Ept.Self.String()+") received Bar:", x)
 	}
 	return *end
 }

--- a/test/pair/pair05/main.go
+++ b/test/pair/pair05/main.go
@@ -129,11 +129,11 @@ func runW(w *W11_K.Init) W11_K.End {
 	case *W11_K.Foo:
 		var x int
 		end = c.Recv_Foo(&x)
-		fmt.Println("W(" + w.Ept.Self.Tostring() + ") received Foo:", x)
-	case *W11_K.Bar: 
+		fmt.Println("W("+w.Ept.Self.String()+") received Foo:", x)
+	case *W11_K.Bar:
 		var x string
 		end = c.Recv_Bar(&x)
-		fmt.Println("W(" + w.Ept.Self.Tostring() + ") received Bar:", x)
+		fmt.Println("W("+w.Ept.Self.String()+") received Bar:", x)
 	}
 	return *end
 }

--- a/test/pair/pair06/main.go
+++ b/test/pair/pair06/main.go
@@ -98,11 +98,10 @@ func server_T(wg *sync.WaitGroup, K session2.Pair, self session2.Pair) *T.End {
 
 func runT(s *T.Init) T.End {
 	pay := make([]string, 1)
-	end := s.W_selfpluslneg1r0_Gather_Foo(pay);
-	fmt.Println("T(" + s.Ept.Self.Tostring() + ") gathered Foo:", pay)
+	end := s.W_selfpluslneg1r0_Gather_Foo(pay)
+	fmt.Println("T("+s.Ept.Self.String()+") gathered Foo:", pay)
 	return *end
 }
-
 
 /*
 var seed = rand.NewSource(time.Now().UnixNano())
@@ -110,19 +109,18 @@ var rnd = rand.New(seed)
 //var count = 1
 */
 
-
 // self.X < K.X
 func server_M(wg *sync.WaitGroup, K session2.Pair, self session2.Pair) *M.End {
 	var err error
 	var ss transport2.ScribListener
 	P1 := Proto1.New()
 	M := P1.New_family_1_W_l1r1plusl1r0toKandl1r1toKsubl1r0(K, self)
-	if ss, err = LISTEN(PORT+self.Flatten(K)); err != nil {
+	if ss, err = LISTEN(PORT + self.Flatten(K)); err != nil {
 		panic(err)
 	}
 	defer ss.Close()
 	// Accept from below
-	if (self.X == 2) {
+	if self.X == 2 {
 		if err = M.W_l1r1toKsubl1r0_not_l1r1plusl1r0toK_Accept(session2.XY(1, self.Y), ss, FORMATTER()); err != nil {
 			panic(err)
 		}
@@ -153,14 +151,13 @@ func server_M(wg *sync.WaitGroup, K session2.Pair, self session2.Pair) *M.End {
 
 func runM(s *M.Init) M.End {
 	pay := make([]string, 1)
-	s2 := s.W_selfpluslneg1r0_Gather_Foo(pay);
-	fmt.Println("M(" + s.Ept.Self.Tostring() + ") gathered Foo:", pay)
-	pay = []string{pay[0] + "thenM" + s.Ept.Self.Tostring()}
+	s2 := s.W_selfpluslneg1r0_Gather_Foo(pay)
+	fmt.Println("M("+s.Ept.Self.String()+") gathered Foo:", pay)
+	pay = []string{pay[0] + "thenM" + s.Ept.Self.String()}
 	end := s2.W_selfplusl1r0_Scatter_Foo(pay)
-	fmt.Println("M(" + s.Ept.Self.Tostring() + ") scattered Foo:", pay)
+	fmt.Println("M("+s.Ept.Self.String()+") scattered Foo:", pay)
 	return *end
 }
-
 
 // self.X == 1
 func client_B(wg *sync.WaitGroup, K session2.Pair, self session2.Pair) *B.End {
@@ -177,8 +174,8 @@ func client_B(wg *sync.WaitGroup, K session2.Pair, self session2.Pair) *B.End {
 }
 
 func runB(s *B.Init) B.End {
-	pay := []string{"B" + s.Ept.Self.Tostring()}
+	pay := []string{"B" + s.Ept.Self.String()}
 	end := s.W_selfplusl1r0_Scatter_Foo(pay)
-	fmt.Println("B(" + s.Ept.Self.Tostring() + ") scattered Foo:", pay)
+	fmt.Println("B("+s.Ept.Self.String()+") scattered Foo:", pay)
 	return *end
 }


### PR DESCRIPTION
- Type alias of message interface to original implementation
- Rename Tostring to String as per usual Go Stringer interface
- Simplify message interfaces.